### PR TITLE
Use getpass.getuser() as default username and use master parameter in config.ini to set custom username

### DIFF
--- a/Jarvis2_4windows.py
+++ b/Jarvis2_4windows.py
@@ -1,5 +1,5 @@
 import configparser  # isort: skip
-from getpass import getuser
+from getpass import getuser  # isort: skip
 import os  # isort: skip
 
 import gui  # isort: skip

--- a/Jarvis2_4windows.py
+++ b/Jarvis2_4windows.py
@@ -1,4 +1,5 @@
 import configparser  # isort: skip
+from getpass import getuser
 import os  # isort: skip
 
 import gui  # isort: skip
@@ -94,6 +95,8 @@ def main(search_engine, take_command, debug):
 
 def run():
     master = config['DEFAULT']['master']
+    if master == '<your name here>':  # If custom username is not set
+        master = getuser()
 
     search_engine = search_engine_selector(config)
 

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-master = YourName
+master = <your name here>
 search_engine = Google
 debug = False
 musicpath = 

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-master = <your name here>
+master = your name
 search_engine = Google
 debug = False
 musicpath = 


### PR DESCRIPTION
# Description
getpass.getuser() can be used as the default username, and the 'master' parameter in config.ini can be used for a custom username. The feature of using 'master' parameter for a custom username is useful, especially when someone has a username like 'Admin'.
Fixes #60

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
